### PR TITLE
Add API libswd_debug_reset and libswd_debug_enable_reset_vector_catch

### DIFF
--- a/include/libswd.h
+++ b/include/libswd.h
@@ -772,6 +772,7 @@ typedef struct libswd_debug {
 #define LIBSWD_ARM_DEBUG_DCRSR_ADDR  0xE000EDF4
 #define LIBSWD_ARM_DEBUG_DCRDR_ADDR  0xE000EDF8
 #define LIBSWD_ARM_DEBUG_DEMCR_ADDR  0xE000EDFC
+#define LIBSWD_ARM_DEBUG_AIRCR_ADDR  0xE000ED0C /* Application Interrupt and Reset Control Register */
 
 #define LIBSWD_ARM_DEBUG_DHCSR_DBGKEY_BITNUM     16
 #define LIBSWD_ARM_DEBUG_DHCSR_DBGKEY_VAL        0xA05F /* Remember to write this key every time DHCSR is written. */
@@ -948,6 +949,8 @@ int libswd_memap_write_int_32(libswd_ctx_t *libswdctx, libswd_operation_t operat
 int libswd_debug_detect(libswd_ctx_t *libswdctx, libswd_operation_t operation);
 int libswd_debug_init(libswd_ctx_t *libswdctx, libswd_operation_t operation);
 int libswd_debug_halt(libswd_ctx_t *libswdctx, libswd_operation_t operation);
+int libswd_debug_enable_reset_vector_catch(libswd_ctx_t *libswdctx, libswd_operation_t operation);
+int libswd_debug_reset(libswd_ctx_t *libswdctx, libswd_operation_t operation);
 int libswd_debug_run(libswd_ctx_t *libswdctx, libswd_operation_t operation);
 int libswd_debug_is_halted(libswd_ctx_t *libswdctx, libswd_operation_t operation);
 

--- a/libswd_debug.c
+++ b/libswd_debug.c
@@ -134,6 +134,43 @@ int libswd_debug_halt(libswd_ctx_t *libswdctx, libswd_operation_t operation)
  return LIBSWD_ERROR_MAXRETRY;
 }
 
+int libswd_debug_enable_reset_vector_catch(libswd_ctx_t *libswdctx, libswd_operation_t operation)
+{
+    if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
+    if (operation!=LIBSWD_OPERATION_EXECUTE && operation!=LIBSWD_OPERATION_ENQUEUE) return LIBSWD_ERROR_PARAM;
+
+    int retval;
+
+    if (!libswdctx->log.debug.initialized)
+    {
+        retval=libswd_debug_init(libswdctx, operation);
+        if (retval<0) return retval;
+    }
+    int demcr_val=0x00000001;
+    retval=libswd_memap_write_int_32(libswdctx, operation, LIBSWD_ARM_DEBUG_DEMCR_ADDR, 1, &demcr_val);
+    if (retval<0) return retval;
+    return LIBSWD_OK;
+}
+
+int libswd_debug_reset(libswd_ctx_t *libswdctx, libswd_operation_t operation)
+{
+    if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;
+    if (operation!=LIBSWD_OPERATION_EXECUTE && operation!=LIBSWD_OPERATION_ENQUEUE) return LIBSWD_ERROR_PARAM;
+
+    int retval;
+
+    if (!libswdctx->log.debug.initialized)
+    {
+        retval=libswd_debug_init(libswdctx, operation);
+        if (retval<0) return retval;
+    }
+    // Reset the CPU.
+    int aircr_val=0x05FA0004;
+    retval=libswd_memap_write_int_32(libswdctx, operation, LIBSWD_ARM_DEBUG_AIRCR_ADDR, 1, &aircr_val);
+    if (retval<0) return retval;
+    return LIBSWD_OK;
+}
+
 int libswd_debug_run(libswd_ctx_t *libswdctx, libswd_operation_t operation)
 {
  if (libswdctx==NULL) return LIBSWD_ERROR_NULLCONTEXT;


### PR DESCRIPTION
These APIs allow you to perform a software reset for the target CPU by using the following sequence: libswd_debug_halt, libswd_debug_enable_reset_vector_catch, libswd_debug_reset, libswd_debug_run.